### PR TITLE
Fix Server start up issue due to HOST env variable

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,7 +3,7 @@ class UserMailer < ApplicationMailer
 
   def welcome_email
     @user = params[:user]
-    @url  = url_for controller: 'auth', action: 'verify_email', token: @user.confirm_token, host: ENV['HOST']
+    @url  = url_for controller: 'auth', action: 'verify_email', token: @user.confirm_token, host: ENV['HOST_URL']
     mail(to: @user.email, subject: 'Welcome to Job Triage')
   end
 end


### PR DESCRIPTION
# Pull Request Template

## Description

HOST env variable is not allowed in heroku. So replacing it with HOST_URL


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
