### PR TITLE
Add deleteuser API

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,5 +1,5 @@
 class AuthController < ApplicationController
-  skip_before_action :authenticate_request, only: %i[login register verify_email generate_otp verify_otp delete_user] 
+  skip_before_action :authenticate_request, only: %i[login register verify_email generate_otp verify_otp] 
 
   # POST /register
   def register
@@ -31,14 +31,20 @@ class AuthController < ApplicationController
   
   # DELETE /delete_user 
   def delete_user
-    @email = params[:email]
-    @res = User.delete_all( { email: @email } )
-    if @res == 1
-      response = { message: "User with email '" + @email + "' deleted successfully" }
-      render json: response, status: :ok
+    token = authenticate_user
+    if token
+      @email = params[:email]
+      @res = User.delete_all( { email: @email } )
+      if @res == 1
+        response = { message: "User with email '" + @email + "' deleted successfully" }
+        render json: response, status: :ok
+      else
+        response = { message: "Cannot delete user with email '" + @email + "'"}
+        render json: response, status: :bad_request
+      end
+      cookies.delete :token
     else
-      response = { message: "Cannot find user with email '" + @email + "'"}
-      render json: response
+      render json: { message: 'Authorization failed: Invalid login!' }, status: :bad_request
     end
   end
 

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,5 +1,5 @@
 class AuthController < ApplicationController
-  skip_before_action :authenticate_request, only: %i[login register verify_email generate_otp verify_otp] 
+  skip_before_action :authenticate_request, only: %i[login register verify_email generate_otp verify_otp delete_user] 
 
   # POST /register
   def register
@@ -27,6 +27,19 @@ class AuthController < ApplicationController
   def logout
     cookies.delete :token
     render json: { message: 'Logged out'}, status: :ok
+  end
+  
+  # DELETE /delete_user 
+  def delete_user
+    @email = params[:email]
+    @res = User.delete_all( { email: @email } )
+    if @res == 1
+      response = { message: "User with email '" + @email + "' deleted successfully" }
+      render json: response, status: :ok
+    else
+      response = { message: "Cannot find user with email '" + @email + "'"}
+      render json: response
+    end
   end
 
   def test

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,5 +1,5 @@
 class AuthController < ApplicationController
-  skip_before_action :authenticate_request, only: %i[login register verify_email generate_otp verify_otp] 
+  skip_before_action :authenticate_request, only: %i[login register verify_email generate_otp verify_otp delete_user] 
 
   # POST /register
   def register

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   post 'auth/change',        to: 'auth#change_password'
   post 'auth/generateotp',   to: 'auth#generate_otp'
   post 'auth/verifyotp',     to: 'auth#verify_otp'
+  delete 'auth/deleteuser',     to: 'auth#delete_user'
   # Routes for auth ends
 
   resources :applications do


### PR DESCRIPTION
Adds delete user API to existing APIs. 
Takes `email` as param and deletes user by email (considered to be unique).
Usage:
`curl --location --request DELETE 'http://localhost:3000/auth/deleteuser' \
--header 'Content-Type: application/json' \
--data-raw '{
        "email": "test@test.com",
        "password": "test"
}'`
